### PR TITLE
DNF no longer offers the Python2 variants

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -35,14 +35,14 @@ natively on some Linux distributions.
 
   .. code-block:: console
 
-    # dnf install python2-openstackclient
+    # dnf install python-openstackclient
 
   In order to use the `DNS service`_ you also need the designate
   client package:
 
   .. code-block:: console
 
-    # dnf install python2-designateclient
+    # dnf install python-designateclient
 
 
 **RHEL7 at UiO**

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -35,14 +35,14 @@ natively on some Linux distributions.
 
   .. code-block:: console
 
-    # dnf install python-openstackclient
+    # dnf install python3-openstackclient
 
   In order to use the `DNS service`_ you also need the designate
   client package:
 
   .. code-block:: console
 
-    # dnf install python-designateclient
+    # dnf install python3-designateclient
 
 
 **RHEL7 at UiO**


### PR DESCRIPTION
```
$ sudo dnf install python2-openstackclient
Last metadata expiration check: 0:21:39 ago on Thu 05 Mar 2020 10:13:18 PM CET.
No match for argument: python2-openstackclient
Error: Unable to find a match: python2-openstackclient
```

 Python3 variants seems to work just fine (tested on Fedora 31):
```
bash-5.0$ sudo dnf install python-openstackclient
Last metadata expiration check: 0:21:47 ago on Thu 05 Mar 2020 10:13:18 PM CET.
Dependencies resolved.
================================================================================
 Package                        Arch      Version              Repository  Size
================================================================================
Installing:
 python3-openstackclient        noarch    3.18.0-3.fc31        fedora     997 k
Installing dependencies:
 python-openstackclient-lang    noarch    3.18.0-3.fc31        fedora      60 k
 python-oslo-i18n-lang          noarch    3.23.1-3.fc31        fedora      13 k
 python-oslo-log-lang           noarch    3.42.3-2.fc31        fedora      13 k
 python-oslo-utils-lang         noarch    3.40.3-2.fc31        fedora      12 k
 python3-appdirs                noarch    1.4.3-9.fc31         fedora      22 k
 python3-attrs                  noarch    19.1.0-2.fc31        fedora      60 k
 python3-babel                  noarch    2.7.0-2.fc31         fedora     5.5 M
 python3-cinderclient           noarch    4.2.0-2.fc31         fedora     248 k
 python3-cliff                  noarch    2.15.0-2.fc31        fedora      92 k
 python3-cmd2                   noarch    0.9.16-1.fc31        fedora     175 k
 python3-colorama               noarch    0.4.1-2.fc31         fedora      33 k
 python3-debtcollector          noarch    1.21.0-2.fc31        fedora      32 k
 python3-dogpile-cache          noarch    0.6.8-2.fc31         fedora      74 k
 python3-funcsigs               noarch    1.0.2-13.fc31        fedora      29 k
 python3-glanceclient           noarch    1:2.16.0-2.fc31      fedora     141 k
 python3-importlib-metadata     noarch    0.23-1.fc31          fedora      41 k
 python3-iso8601                noarch    0.1.11-13.fc31       fedora      22 k
 python3-jeepney                noarch    0.4.2-1.fc31         updates    4.7 M
 python3-jmespath               noarch    0.9.4-2.fc31         fedora      45 k
 python3-jsonpatch              noarch    1.21-8.fc31          fedora      25 k
 python3-jsonpointer            noarch    1.10-16.fc31         fedora      18 k
 python3-jsonschema             noarch    3.2.0-1.fc31         updates    106 k
 python3-keyring                noarch    21.1.0-1.fc31        updates     74 k
 python3-keystoneauth1          noarch    3.13.1-2.fc31        fedora     389 k
 python3-keystoneclient         noarch    1:3.19.0-2.fc31      fedora     234 k
 python3-monotonic              noarch    1.5-3.fc31           fedora      17 k
 python3-msgpack                x86_64    0.6.1-3.fc31         fedora      95 k
 python3-munch                  noarch    2.3.2-4.fc31         fedora      21 k
 python3-netaddr                noarch    0.7.19-17.fc31       fedora     1.4 M
 python3-netifaces              x86_64    0.10.6-7.fc31        fedora      23 k
 python3-neutronclient          noarch    6.12.0-2.fc31        fedora     295 k
 python3-novaclient             noarch    1:13.0.0-2.fc31      fedora     212 k
 python3-openstacksdk           noarch    0.27.0-2.fc31        fedora     611 k
 python3-os-client-config       noarch    1.32.0-3.fc31        fedora      53 k
 python3-os-service-types       noarch    1.6.0-3.fc31         fedora      36 k
 python3-osc-lib                noarch    1.12.1-3.fc31        fedora      73 k
 python3-oslo-config            noarch    2:6.8.1-3.fc31       fedora     216 k
 python3-oslo-context           noarch    2.22.1-2.fc31        fedora      25 k
 python3-oslo-i18n              noarch    3.23.1-3.fc31        fedora      57 k
 python3-oslo-log               noarch    3.42.3-2.fc31        fedora      62 k
 python3-oslo-serialization     noarch    2.28.2-2.fc31        fedora      32 k
 python3-oslo-utils             noarch    3.40.3-2.fc31        fedora      76 k
 python3-pbr                    noarch    5.1.2-4.fc31         fedora     1.0 M
 python3-prettytable            noarch    0.7.2-18.fc31        fedora      41 k
 python3-pyperclip              noarch    1.6.4-4.fc31         fedora      22 k
 python3-pyrsistent             x86_64    0.15.7-1.fc31        updates    105 k
 python3-pytz                   noarch    2019.2-1.fc31        fedora      48 k
 python3-pyyaml                 x86_64    5.3-3.fc31           updates    207 k
 python3-requestsexceptions     noarch    1.4.0-2.fc31         fedora      15 k
 python3-rfc3986                noarch    1.2.0-4.fc31         fedora      45 k
 python3-secretstorage          noarch    3.1.1-2.fc31         fedora      33 k
 python3-simplejson             x86_64    3.16.0-3.fc31        fedora     259 k
 python3-stevedore              noarch    1.30.1-2.fc31        fedora      61 k
 python3-warlock                noarch    1.3.0-11.fc31        fedora      20 k
 python3-wcwidth                noarch    0.1.7-11.fc31        fedora      31 k
 python3-wrapt                  x86_64    1.11.2-2.fc31        fedora      53 k
 python3-zipp                   noarch    0.5.1-2.fc31         fedora      14 k

Transaction Summary
================================================================================
Install  58 Packages
```