### PR TITLE
Added Terraform 0.12 requirement

### DIFF
--- a/docs/terraform-part1.rst
+++ b/docs/terraform-part1.rst
@@ -23,7 +23,7 @@ Prerequisites
 
 .. _OpenStack CLI tools: api.html
 
-You need to download and install Terraform_ (example):
+You need to download and install Terraform_ version 0.12 (newer versions will not work without rewriting the code for 0.13 or newer)  (example):
 
 .. code-block:: console
 


### PR DESCRIPTION
The doc links to Terraform download, which offers 0.14 by default (which is the newest now). The code in the examples will not work with 0.14, so I have updated the doc to reflect that it needs version 0.12.