### PR TITLE
Add a comment on Object storage and an extra env_var to set

### DIFF
--- a/docs/object.rst
+++ b/docs/object.rst
@@ -124,8 +124,17 @@ environment variables:
   export AWS_ACCESS_KEY_ID=<access_key>
   export AWS_SECRET_ACCESS_KEY=<secret_key>
   export AWS_ENDPOINT_URL=https://object.api.<region>.nrec.no:8080
+  export AWS_DEFAULT_REGION=None
 
 See `AWS CLI`_ for more information.
+
+.. NOTE::
+  `AWS_ENDPOINT_URL` was introduced in AWS_CLI 2.13 (2023) and may not be available in the version supplied from the OS aws cli package.
+  The endpoint url can be set by supplying it as a parameter:
+
+.. code block:: console
+
+  aws --endpoint-url $AWS_ENDPOINT_URL command...
 
 Public Access (S3)
 ==================


### PR DESCRIPTION
When I run the official aws docker image

amazon/aws-cli

with the following env vars set

`AWS_ENDPOINT_URL`
`AWS_SECRET_ACCESS_KEY`
`AWS_ACCESS_KEY_ID`

I get the error message 'Provided region_name 'bgo-default-' doesn't match a supported format, when I run the command:

```
 aws s3 sync --delete  --exclude "*.xml" wab2wsimport/bemerkung s3://wittgenstein-bucket/bemerkung
````

The [official amazon docs](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html) also says to export a default region name: 
```
$ export AWS_DEFAULT_REGION=us-west-2 # None for NREC
````
 so I thought it would be simpler to add it to the docs, rather then explaining the bug to the user, even if it works in some cases without having it set.

I first looked at `AWS_EC2_METADATA_DISABLED=TRUE` which also works to fix it, but having a default region set looks cleaner to me, and follows the official docs.

I also added a Note on using a param as an alternative for `AWS_ENDPOINT_URL`, since I had trouble with following the guide when installing the cli from DNF.